### PR TITLE
Add left padding to icon on mobile

### DIFF
--- a/src/components/ProjectTable.js
+++ b/src/components/ProjectTable.js
@@ -4,8 +4,6 @@ import styled from 'styled-components'
 
 import Avatar from './Avatar'
 import StarDelta from './StarDelta'
-import TagLabel from './TagLabel'
-import Description from './Description'
 import GrowthScore from './GrowthScore'
 import { getUrl } from '../utils/project-helpers'
 
@@ -104,6 +102,11 @@ const RankingCell = styled(Cell)`
 
 const IconCell = styled(Cell)`
   width: 50px;
+
+  @media (max-width: ${breakPoint - 1}px) {
+    width: 60px;
+    padding-left: 10px;
+  }
 `
 
 const MainCell = styled(Cell)`


### PR DESCRIPTION
I added 10px of left padding so it isn't squashed against the container. Related to https://github.com/bestofjs/javascript-risingstars/issues/55

## Before:
![localhost_3000_issues_103(iPhone 6_7_8) -- before](https://user-images.githubusercontent.com/7598058/82766689-5e0c3d00-9e64-11ea-8709-4f26a80753ff.png)

## After:
![localhost_3000_issues_103(iPhone 6_7_8)](https://user-images.githubusercontent.com/7598058/82766687-5ba9e300-9e64-11ea-8575-11fe593e3e3e.png)
